### PR TITLE
Add GitHub Actions unit test workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,25 @@
+name: R package tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: r-lib/actions/setup-r@v2
+      - name: Install dependencies
+        run: |
+          install.packages(c("remotes", "testthat"))
+          remotes::install_deps("DescriptiveRepresentationCalculator", dependencies = TRUE)
+        shell: Rscript {0}
+      - name: Install package
+        run: R CMD INSTALL DescriptiveRepresentationCalculator
+      - name: Run unit tests
+        run: |
+          R -q -e 'testthat::test_dir("DescriptiveRepresentationCalculator/tests/testthat")'
+


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to run the package unit tests

## Testing
- `R -q -e 'testthat::test_dir("DescriptiveRepresentationCalculator/tests/testthat")'`

------
https://chatgpt.com/codex/tasks/task_e_683cc8c11f90832fa4827fc0ac346923