### PR TITLE
Fix typo in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ ExpectedRep <- ExpectedRepresentation(
 print( ExpectedRep )
 
 ##################
-# Compute the amount of representation left on explained under 
+# Compute the amount of representation left unexplained under
 # the random sampling model for the same body and population
 ResidualRep <- SDRepresentation(
   PopShares = c(1/3, 2/3, 1/3),


### PR DESCRIPTION
## Summary
- fix grammar for 'Compute the amount of representation left unexplained'

## Testing
- `R -q -e 'library(testthat); testthat::test_dir("DescriptiveRepresentationCalculator/tests/testthat")'`

------
https://chatgpt.com/codex/tasks/task_e_683db393dfe4832fb98688dc8d9afc26