### PR TITLE
Fix NaN issue in ExpectedRepresentation when PopShares contains 1

### DIFF
--- a/DescriptiveRepresentationCalculator/R/ExpectedRep.R
+++ b/DescriptiveRepresentationCalculator/R/ExpectedRep.R
@@ -45,24 +45,26 @@
 
 ExpectedRepresentation <- function(PopShares, BodyN, a = -0.5, b = 1){
   # if any pop shares are NA, return NA
-  if(any(is.na(PopShares))){return( NA) } 
+  if(any(is.na(PopShares))){return( NA) }
 
-  if(length(PopShares) > 1){
-    theoretical_means_log <- log(2) +
-      (BodyN - floor(BodyN*PopShares))*log(1 - PopShares) +
-      (floor(BodyN*PopShares)+1)*log(PopShares) +
-      log(floor(BodyN*PopShares)+1) +
-      lchoose(BodyN,floor(BodyN*PopShares)+1)
-    theoretical_means <- exp(  theoretical_means_log )
-    theoretical_mean <- sum( theoretical_means / BodyN )
-  }
-  if(length(PopShares) == 1){theoretical_mean <- 0}
+  # if one group makes up the entire population, avoid computing log(0)
   if(abs(max(PopShares) - 1) < 10^(-10)){
     theoretical_means <- 2 * (1 - PopShares)^(BodyN - floor(BodyN*PopShares)) *
-      PopShares^(floor(BodyN*PopShares)+1)*
-      (floor(BodyN*PopShares)+1)*
-      choose(BodyN,floor(BodyN*PopShares)+1)
-    theoretical_mean <- sum( theoretical_means / BodyN )
+      PopShares^(floor(BodyN*PopShares)+1) *
+      (floor(BodyN*PopShares)+1) *
+      choose(BodyN, floor(BodyN*PopShares)+1)
+    theoretical_mean <- sum(theoretical_means / BodyN)
+  } else if(length(PopShares) > 1) {
+    theoretical_means_log <- log(2) +
+      (BodyN - floor(BodyN*PopShares)) * log(1 - PopShares) +
+      (floor(BodyN*PopShares)+1) * log(PopShares) +
+      log(floor(BodyN*PopShares)+1) +
+      lchoose(BodyN, floor(BodyN*PopShares)+1)
+    theoretical_means <- exp(theoretical_means_log)
+    theoretical_mean <- sum(theoretical_means / BodyN)
+  } else {
+    theoretical_mean <- 0
   }
-  return( a * theoretical_mean + b )
+
+  return(a * theoretical_mean + b)
 }


### PR DESCRIPTION
## Summary
- avoid computing log(0) when population share equals 1

## Testing
- `R -q -e 'library(testthat); test_dir("DescriptiveRepresentationCalculator/tests/testthat")'`

------
https://chatgpt.com/codex/tasks/task_e_684045691b74832f9bfcf8d85c56a7a5